### PR TITLE
Update pry-byebug and awesome-print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+
+* Update [pry-byebug][pry-byebug] to v2.0.0
 ## 0.5.4 (2014-11-06)
 
 * Remove [pry-stack_explorer][pry-stack_explorer]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Update [pry-byebug][pry-byebug] to v2.0.0
+* Update [awesome-print][awesome-print] to v1.6.1
+
 ## 0.5.4 (2014-11-06)
 
 * Remove [pry-stack_explorer][pry-stack_explorer]

--- a/jazz_fingers.gemspec
+++ b/jazz_fingers.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pry-byebug', '~> 2.0.0'
   gem.add_runtime_dependency 'hirb', '~> 0.7'
   gem.add_runtime_dependency 'pry-coolline', '~> 0.2'
-  gem.add_runtime_dependency 'awesome_print', '~> 1.2'
+  gem.add_runtime_dependency 'awesome_print', '~> 1.6.1'
   gem.add_runtime_dependency 'railties', '>= 3.0', '< 5.0'
 end

--- a/jazz_fingers.gemspec
+++ b/jazz_fingers.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pry-doc', '~> 0.6'
   gem.add_runtime_dependency 'pry-git', '~> 0.2'
   gem.add_runtime_dependency 'pry-remote', '>= 0.1.7'
-  gem.add_runtime_dependency 'pry-byebug', '~> 1.3'
+  gem.add_runtime_dependency 'pry-byebug', '~> 2.0.0'
   gem.add_runtime_dependency 'hirb', '~> 0.7'
   gem.add_runtime_dependency 'pry-coolline', '~> 0.2'
   gem.add_runtime_dependency 'awesome_print', '~> 1.2'


### PR DESCRIPTION
Updates pry-byebug and awesome print to the latest versions. 

Current version fails on Ruby 2.2.0:
![jazzy_fingers sh 2015-01-18 10-47-35](https://cloud.githubusercontent.com/assets/1889575/5793619/7fb47874-9eff-11e4-8f7b-002e7f0dda46.png)

Tested on Ruby 2.2.0
