### PR TITLE
Downgrade pry-byebug to a version that works with pry-remote

### DIFF
--- a/jazz_fingers.gemspec
+++ b/jazz_fingers.gemspec
@@ -22,7 +22,10 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "pry", "~> 0.10"
   gem.add_runtime_dependency "pry-doc", "~> 0.6"
   gem.add_runtime_dependency "pry-remote", ">= 0.1.7"
-  gem.add_runtime_dependency "pry-byebug", "~> 3.1"
+  # This is pinned because of compatibility issues with pry remote.
+  # See: https://github.com/deivid-rodriguez/pry-byebug/issues/33
+  # And: https://github.com/Mon-Ouie/pry-remote/issues/58
+  gem.add_runtime_dependency "pry-byebug", "1.3.3"
   gem.add_runtime_dependency "hirb", "~> 0.7"
   gem.add_runtime_dependency "pry-coolline", "~> 0.2"
   gem.add_runtime_dependency "awesome_print", "~> 1.6"


### PR DESCRIPTION
As per the conversation here: https://github.com/plribeiro3000/jazz_fingers/commit/4f2077a2852cd0eba50cae8cca53b410798815e8

There are compatibility issues with `pry-byebug` (greater than `1.3.3`) and `pry-remote`. Until they are sorted out, we should use version `1.3.3` of `pry-byebug` so that we can use `pry-remote`.

This was addressed here: https://github.com/plribeiro3000/jazz_fingers/commit/f8633e72b6cab250fd02664dd2444c0288b6a40b but was later reverted here: https://github.com/plribeiro3000/jazz_fingers/commit/4f2077a2852cd0eba50cae8cca53b410798815e8
