### PR TITLE
Remove pry-remote dependency

### DIFF
--- a/jazz_fingers.gemspec
+++ b/jazz_fingers.gemspec
@@ -21,11 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0"
   gem.add_runtime_dependency "pry", "~> 0.10"
   gem.add_runtime_dependency "pry-doc", "~> 0.6"
-  gem.add_runtime_dependency "pry-remote", ">= 0.1.7"
-  # This is pinned because of compatibility issues with pry remote.
-  # See: https://github.com/deivid-rodriguez/pry-byebug/issues/33
-  # And: https://github.com/Mon-Ouie/pry-remote/issues/58
-  gem.add_runtime_dependency "pry-byebug", "1.3.3"
+  gem.add_runtime_dependency "pry-byebug", "~> 3.4"
   gem.add_runtime_dependency "hirb", "~> 0.7"
   gem.add_runtime_dependency "pry-coolline", "~> 0.2"
   gem.add_runtime_dependency "awesome_print", "~> 1.6"


### PR DESCRIPTION
Up to you to decide how you want to handle the version bump. :)
