### PR TITLE
Use non deprecated method name

### DIFF
--- a/lib/jazz_fingers/prompt.rb
+++ b/lib/jazz_fingers/prompt.rb
@@ -37,7 +37,7 @@ module JazzFingers
     end
 
     def line_number(pry)
-      "[#{bold_text(pry.input_array.size)}]"
+      "[#{bold_text(pry.input_ring.size)}]"
     end
 
     def text(object, level)

--- a/lib/jazz_fingers/prompt.rb
+++ b/lib/jazz_fingers/prompt.rb
@@ -37,9 +37,11 @@ module JazzFingers
     end
 
     def line_number(pry)
-      pry.respond_to? :input_ring ?
-        "[#{bold_text(pry.input_ring.size)}]" :
+      if pry.respond_to? :input_ring
+        "[#{bold_text(pry.input_ring.size)}]"
+      else
         "[#{bold_text(pry.input_array.size)}]"
+      end
     end
 
     def text(object, level)

--- a/lib/jazz_fingers/prompt.rb
+++ b/lib/jazz_fingers/prompt.rb
@@ -37,7 +37,9 @@ module JazzFingers
     end
 
     def line_number(pry)
-      "[#{bold_text(pry.input_ring.size)}]"
+      pry.respond_to? :input_ring ?
+        "[#{bold_text(pry.input_ring.size)}]" :
+        "[#{bold_text(pry.input_array.size)}]"
     end
 
     def text(object, level)


### PR DESCRIPTION
In prompt.rb:40 use Pry#input_ring vice Pry#input_array, which is being deprecated as per https://github.com/pry/pry/pull/1814