### PR TITLE
fix(AwesomePrint): Replace with amazing_print

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ hard-working fingers!
 **jazz_fingers** is an opinionated set of console-related gems and a bit of glue:
 
 * [**Pry**][pry] for a powerful shell alternative to IRB.
-* [**Awesome Print**][awesome_print] for stylish pretty print.
+* [**Amazing Print**][amazing_print] for stylish pretty print.
   console.
 * [**Pry Coolline**][pry-coolline] for syntax highlighting as you type.
 
@@ -46,7 +46,7 @@ Some configurations can be overwritten:
 if defined?(JazzFingers)
   JazzFingers.configure do |config|
     config.colored_prompt = false
-    config.awesome_print = false
+    config.amazing_print = false
     config.coolline = false
     config.application_name = MyAwesomeProject
   end
@@ -69,7 +69,7 @@ mixed encodings.
 
 
 [pry]:                http://pry.github.com
-[awesome_print]:      https://github.com/michaeldv/awesome_print
+[amazing_print]:      https://github.com/amazing-print/amazing_print
 [hirb]:               https://github.com/cldwalker/hirb
 [pry-doc]:            https://github.com/pry/pry-doc
 [pry-coolline]:       https://github.com/pry/pry-coolline

--- a/jazz_fingers.gemspec
+++ b/jazz_fingers.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Exercise those fingers. Pry-based enhancements for the default Ruby console.'
   description =
     'Spending hours in the ruby console? Spruce it up and show off those hard-working hands! jazz_fingers'\
-    'replaces IRB with Pry, improves output through awesome_print, and has some other goodies up its sleeves.'
+    'replaces IRB with Pry, improves output through amazing_print, and has some other goodies up its sleeves.'
   gem.description   = description
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 2.0'
-  gem.add_runtime_dependency 'awesome_print', '~> 1.6'
+  gem.add_runtime_dependency 'amazing_print', '~> 1.2'
   gem.add_runtime_dependency 'pry', '~> 0.10'
   gem.add_runtime_dependency 'pry-byebug', '~> 3.4'
   gem.add_runtime_dependency 'pry-coolline', '~> 0.2'

--- a/lib/jazz_fingers.rb
+++ b/lib/jazz_fingers.rb
@@ -6,7 +6,7 @@ require 'readline'
 require 'forwardable'
 
 module JazzFingers
-  autoload :AWESOME_PRINT, 'jazz_fingers/awesome_print'
+  autoload :AMAZING_PRINT, 'jazz_fingers/amazing_print'
   autoload :CodeRay, 'jazz_fingers/coderay'
   autoload :Commands, 'jazz_fingers/commands'
   autoload :Configuration, 'jazz_fingers/configuration'
@@ -18,7 +18,7 @@ module JazzFingers
   class << self
     extend Forwardable
 
-    def_delegators :config, :awesome_print?, :coolline?
+    def_delegators :config, :amazing_print?, :coolline?
 
     def print
       @print ||= Print.config
@@ -66,10 +66,10 @@ module JazzFingers
         Pry.config.commands.import(command)
       end
 
-      if JazzFingers.awesome_print?
-        require 'awesome_print'
+      if JazzFingers.amazing_print?
+        require 'amazing_print'
 
-        AwesomePrint.defaults = JazzFingers::AWESOME_PRINT
+        AmazingPrint.defaults = JazzFingers::AMAZING_PRINT
         Pry.print = print
       end
 

--- a/lib/jazz_fingers/amazing_print.rb
+++ b/lib/jazz_fingers/amazing_print.rb
@@ -1,22 +1,22 @@
 module JazzFingers
-  AWESOME_PRINT = {
+  AMAZING_PRINT = {
     indent: 2,
     sort_keys: true,
     color: {
       args: :greenish,
-      array: :pale,
+      array: :whiteish,
       bigdecimal: :blue,
       class: :yellow,
       date: :greenish,
       falseclass: :red,
       fixnum: :blue,
       float: :blue,
-      hash: :pale,
+      hash: :whiteish,
       keyword: :cyan,
       method: :purpleish,
       nilclass: :red,
       string: :yellowish,
-      struct: :pale,
+      struct: :whiteish,
       symbol: :cyanish,
       time: :greenish,
       trueclass: :green,

--- a/lib/jazz_fingers/configuration.rb
+++ b/lib/jazz_fingers/configuration.rb
@@ -1,6 +1,6 @@
 module JazzFingers
   class Configuration
-    attr_writer :colored_prompt, :prompt_separator, :coolline, :awesome_print,
+    attr_writer :colored_prompt, :prompt_separator, :coolline, :amazing_print,
                 :application_name
 
     # Color the prompt?
@@ -32,10 +32,10 @@ module JazzFingers
       @coolline
     end
 
-    def awesome_print?
-      return true if @awesome_print.nil?
+    def amazing_print?
+      return true if @amazing_print.nil?
 
-      @awesome_print
+      @amazing_print
     end
 
     def application_name

--- a/lib/jazz_fingers/print.rb
+++ b/lib/jazz_fingers/print.rb
@@ -1,4 +1,4 @@
-require 'awesome_print'
+require 'amazing_print'
 
 module JazzFingers
   class Print


### PR DESCRIPTION
AwesomePrint is stale and no longer maintained. This patch replaces it with AmazingPrint, a maintained fork. 

```
2.7.1 (jazz_fingers)[5] » Array([3])
~/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/gems/awesome_print-1.8.0/lib/awesome_print/formatters/base_formatter.rb:113: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
~/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/gems/awesome_print-1.8.0/lib/awesome_print/inspector.rb:63: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

### After:

```
2.7.1 (jazz_fingers)[1] » Array(3)
=> [
    [0] 3
]
```

Fixes #27 