### PR TITLE
7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 7.0.0 (2026-03-24)
 * Replace `readline` with `reline` for Ruby 4.0 compatibility
 * Remove `pry-byebug` runtime dependency and debugger aliases
 * Simplify `colored_prompt` and `prompt_separator` defaults

--- a/lib/jazz_fingers/version.rb
+++ b/lib/jazz_fingers/version.rb
@@ -1,3 +1,3 @@
 module JazzFingers
-  VERSION = '6.3.0'.freeze
+  VERSION = '7.0.0'.freeze
 end


### PR DESCRIPTION
* Replace `readline` with `reline` for Ruby 4.0 compatibility
* Remove `pry-byebug` runtime dependency and debugger aliases
* Simplify `colored_prompt` and `prompt_separator` defaults